### PR TITLE
Feature / Mocking Singleton Services

### DIFF
--- a/src/blueprints/Do.Blueprints.Service.Application/Core/Mock/MockCoreFeature.cs
+++ b/src/blueprints/Do.Blueprints.Service.Application/Core/Mock/MockCoreFeature.cs
@@ -9,9 +9,8 @@ public class MockCoreFeature : IFeature<CoreConfigurator>
     {
         configurator.ConfigureTestConfiguration(test =>
         {
-            test.Mocks.Add<ISystem>(singleton: true);
-
             test.Mocks.Add<IConfiguration>(singleton: true);
+            test.Mocks.Add<ISystem>(singleton: true);
         });
     }
 }

--- a/src/blueprints/Do.Blueprints.Service.Application/Core/Mock/MockCoreFeature.cs
+++ b/src/blueprints/Do.Blueprints.Service.Application/Core/Mock/MockCoreFeature.cs
@@ -1,4 +1,5 @@
 using Do.Architecture;
+using Microsoft.Extensions.Configuration;
 
 namespace Do.Core.Mock;
 
@@ -9,6 +10,8 @@ public class MockCoreFeature : IFeature<CoreConfigurator>
         configurator.ConfigureTestConfiguration(test =>
         {
             test.Mocks.Add<ISystem>(singleton: true);
+
+            test.Mocks.Add<IConfiguration>(singleton: true);
         });
     }
 }

--- a/src/blueprints/Do.Blueprints.Service.Application/Do.Blueprints.Service.Application.csproj
+++ b/src/blueprints/Do.Blueprints.Service.Application/Do.Blueprints.Service.Application.csproj
@@ -18,8 +18,6 @@
 
   <ItemGroup>
     <PackageReference Include="FluentNHibernate" Version="3.2.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
     <PackageReference Include="MySql.Data" Version="8.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.20" />
     <PackageReference Include="NHibernate" Version="5.4.4" />

--- a/src/blueprints/Do.Blueprints.Service.Application/Do.Blueprints.Service.Application.csproj
+++ b/src/blueprints/Do.Blueprints.Service.Application/Do.Blueprints.Service.Application.csproj
@@ -18,6 +18,8 @@
 
   <ItemGroup>
     <PackageReference Include="FluentNHibernate" Version="3.2.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
     <PackageReference Include="MySql.Data" Version="8.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.20" />
     <PackageReference Include="NHibernate" Version="5.4.4" />

--- a/src/blueprints/Do.Blueprints.Service.Application/MockOverrider/FirstInterface/MockOverrider.cs
+++ b/src/blueprints/Do.Blueprints.Service.Application/MockOverrider/FirstInterface/MockOverrider.cs
@@ -1,10 +1,12 @@
-﻿using System.Collections.Concurrent;
+﻿using Moq;
+using System.Collections.Concurrent;
 
 namespace Do.MockOverrider.FirstInterface;
 
 public class MockOverrider : IMockOverrider
 {
     readonly ConcurrentDictionary<Type, object> _overrides = new();
+    readonly List<(Type, object)> _resetMocks = new();
 
     public object? Get(Type type)
     {
@@ -16,5 +18,20 @@ public class MockOverrider : IMockOverrider
     public void Override(object mocked)
     {
         _overrides.TryAdd(mocked.GetType().GetInterfaces().First(), mocked);
+    }
+
+    public void Reset()
+    {
+        _overrides.Clear();
+
+        foreach (var (_, mock) in _resetMocks)
+        {
+            Mock.Get(mock).Reset();
+        }
+    }
+
+    internal void ResetEventually(Type type, object mock)
+    {
+        _resetMocks.Add((type, mock));
     }
 }

--- a/src/blueprints/Do.Blueprints.Service.Application/MockOverrider/FirstInterface/MockOverrider.cs
+++ b/src/blueprints/Do.Blueprints.Service.Application/MockOverrider/FirstInterface/MockOverrider.cs
@@ -30,7 +30,7 @@ public class MockOverrider : IMockOverrider
             var getMethod = typeof(Mock).GetMethod(nameof(Mock.Get), BindingFlags.Static | BindingFlags.Public) ?? throw new InvalidOperationException("method should not be null");
             var genericGetMethod = getMethod.MakeGenericMethod(type);
 
-            Mock mock = (Mock)(genericGetMethod.Invoke(null, new[] { mockedObject }) ?? throw new Exception());
+            Mock mock = (Mock)(genericGetMethod.Invoke(null, new[] { mockedObject }) ?? throw new InvalidOperationException("invoke result should not be null"));
 
             mock.Reset();
         }

--- a/src/blueprints/Do.Blueprints.Service.Application/MockOverrider/FirstInterface/MockOverriderMockFactory.cs
+++ b/src/blueprints/Do.Blueprints.Service.Application/MockOverrider/FirstInterface/MockOverriderMockFactory.cs
@@ -9,6 +9,13 @@ public class MockOverriderMockFactory : DefaultMockFactory
     {
         var overrider = serviceProvider.GetRequiredService<MockOverrider>();
 
-        return overrider.Get(mockDescriptor.Type) ?? base.Create(serviceProvider, mockDescriptor);
+        var result = overrider.Get(mockDescriptor.Type) ?? base.Create(serviceProvider, mockDescriptor);
+
+        if (mockDescriptor.Singleton)
+        {
+            overrider.ResetEventually(mockDescriptor.Type, result);
+        }
+
+        return result;
     }
 }

--- a/src/blueprints/Do.Blueprints.Service.Application/MockOverrider/IMockOverrider.cs
+++ b/src/blueprints/Do.Blueprints.Service.Application/MockOverrider/IMockOverrider.cs
@@ -3,4 +3,5 @@ namespace Do.MockOverrider;
 public interface IMockOverrider
 {
     void Override(object mocked);
+    void Reset();
 }

--- a/src/blueprints/Do.Blueprints.Service.Application/ServiceSpec.cs
+++ b/src/blueprints/Do.Blueprints.Service.Application/ServiceSpec.cs
@@ -92,7 +92,6 @@ public abstract class ServiceSpec : Spec
                return mockSection.Object;
            });
 
-
         MockMe.TheSystem(new DateTime(2023, 09, 09, 10, 10, 00));
     }
 

--- a/src/blueprints/Do.Blueprints.Service.Application/ServiceSpec.cs
+++ b/src/blueprints/Do.Blueprints.Service.Application/ServiceSpec.cs
@@ -74,24 +74,7 @@ public abstract class ServiceSpec : Spec
 
         Settings = new();
 
-        Mock.Get(GiveMe.The<IConfiguration>())
-           .Setup(c => c.GetSection(It.IsAny<string>())).Returns((string key) =>
-           {
-               var mockSection = new Mock<IConfigurationSection>();
-
-               mockSection.Setup(s => s.Value).Returns(() =>
-               {
-                   if (Settings.TryGetValue(key, out var result))
-                   {
-                       return result;
-                   }
-
-                   return key.EndsWith("Url") ? "https://test.com?value" : "test value";
-               });
-
-               return mockSection.Object;
-           });
-
+        MockMe.TheSettings(Settings);
         MockMe.TheSystem(new DateTime(2023, 09, 09, 10, 10, 00));
     }
 

--- a/src/blueprints/Do.Blueprints.Service.Application/ServiceSpec.cs
+++ b/src/blueprints/Do.Blueprints.Service.Application/ServiceSpec.cs
@@ -6,9 +6,7 @@ using Do.ExceptionHandling;
 using Do.MockOverrider;
 using Do.Orm;
 using Do.Testing;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Moq;
 using NHibernate;
 
 using ITransaction = NHibernate.ITransaction;
@@ -74,8 +72,8 @@ public abstract class ServiceSpec : Spec
 
         Settings = new();
 
-        MockMe.TheSettings(Settings);
-        MockMe.TheSystem(new DateTime(2023, 09, 09, 10, 10, 00));
+        MockMe.TheConfiguration(settings: Settings);
+        MockMe.TheSystem(now: new DateTime(2023, 09, 09, 10, 10, 00));
     }
 
     public override void TearDown()

--- a/src/blueprints/Do.Blueprints.Service.Application/ServiceSpec.cs
+++ b/src/blueprints/Do.Blueprints.Service.Application/ServiceSpec.cs
@@ -64,14 +64,16 @@ public abstract class ServiceSpec : Spec
     }
 
     ITransaction _transaction = default!;
-    internal Dictionary<string, string> Settings { get; private set; } = default!;
-    internal DateTime SystemNow { get; private set; } = default!;
+    public Dictionary<string, string> Settings { get; private set; } = default!;
+    public DateTime SystemNow { get; private set; } = default!;
 
     public override void SetUp()
     {
         base.SetUp();
 
         _transaction = _session.BeginTransaction();
+
+        Settings = new();
 
         Mock.Get(GiveMe.The<IConfiguration>())
            .Setup(c => c.GetSection(It.IsAny<string>())).Returns((string key) =>

--- a/src/blueprints/Do.Blueprints.Service.Application/ServiceSpec.cs
+++ b/src/blueprints/Do.Blueprints.Service.Application/ServiceSpec.cs
@@ -64,8 +64,7 @@ public abstract class ServiceSpec : Spec
     }
 
     ITransaction _transaction = default!;
-    public Dictionary<string, string> Settings { get; private set; } = default!;
-    public DateTime SystemNow { get; private set; } = default!;
+    internal Dictionary<string, string> Settings { get; private set; } = default!;
 
     public override void SetUp()
     {
@@ -93,8 +92,8 @@ public abstract class ServiceSpec : Spec
                return mockSection.Object;
            });
 
-        Mock.Get(GiveMe.The<ISystem>())
-           .Setup(c => c.Now).Returns(SystemNow);
+
+        MockMe.TheSystem(new DateTime(2023, 09, 09, 10, 10, 00));
     }
 
     public override void TearDown()

--- a/src/blueprints/Do.Blueprints.Service.Application/ServiceSpecExtensions.cs
+++ b/src/blueprints/Do.Blueprints.Service.Application/ServiceSpecExtensions.cs
@@ -27,11 +27,11 @@ public static class ServiceSpecExtensions
         spec.Settings[key] = value;
     }
 
-    internal static IConfiguration TheConfiguration(this Mocker mockMe, Dictionary<string, string> settings,
-        Func<string, string>? defaultValue = default
+    internal static IConfiguration TheConfiguration(this Mocker mockMe,
+        Dictionary<string, string>? settings = default
     )
     {
-        defaultValue ??= (key) => key.EndsWith("Url") ? "https://test.com?value" : "test value";
+        settings ??= new Dictionary<string, string>();
 
         var configuration = mockMe.Spec.GiveMe.The<IConfiguration>();
 
@@ -47,7 +47,7 @@ public static class ServiceSpecExtensions
                        return result;
                    }
 
-                   return defaultValue(key);
+                   return key.EndsWith("Url") ? "https://test.com?value" : "test value";
                });
 
                return mockSection.Object;
@@ -175,7 +175,8 @@ public static class ServiceSpecExtensions
     #region String Extensions
 
     public static string AString(this Stubber _,
-        string? value = default) => value ?? "string";
+        string? value = default
+    ) => value ?? "test string";
 
     #endregion
 }

--- a/src/blueprints/Do.Blueprints.Service.Application/ServiceSpecExtensions.cs
+++ b/src/blueprints/Do.Blueprints.Service.Application/ServiceSpecExtensions.cs
@@ -12,11 +12,11 @@ namespace Do;
 public static class ServiceSpecExtensions
 {
     #region Settings
-    
+
     public static void TheSetting(this Mocker mocker, string key, string value)
     {
         ((ServiceSpec)mocker.Spec).Settings[key] = value;
-    } 
+    }
 
     #endregion
 
@@ -26,7 +26,7 @@ public static class ServiceSpecExtensions
     {
         Mock.Get(mockMe.Spec.GiveMe.The<ISystem>())
            .Setup(c => c.Now).Returns(now);
-    } 
+    }
 
     #endregion
 

--- a/src/blueprints/Do.Blueprints.Service.Application/ServiceSpecExtensions.cs
+++ b/src/blueprints/Do.Blueprints.Service.Application/ServiceSpecExtensions.cs
@@ -13,19 +13,34 @@ public static class ServiceSpecExtensions
 {
     #region Settings
 
-    public static void TheSetting(this Mocker mocker, string key, string value)
+    public static void ASetting(this Mocker mockMe,
+        string? key = default,
+        string? value = default
+    )
     {
-        ((ServiceSpec)mocker.Spec).Settings[key] = value;
+        key ??= "Test:Configuration";
+        value ??= "value";
+
+        var spec = (ServiceSpec)mockMe.Spec;
+
+        spec.Settings[key] = value;
     }
 
     #endregion
 
     #region System
 
-    public static void TheSystem(this Mocker mockMe, DateTime now)
+    public static void TheSystem(this Mocker mockMe,
+        DateTime? now = default
+    )
     {
-        Mock.Get(mockMe.Spec.GiveMe.The<ISystem>())
-           .Setup(c => c.Now).Returns(now);
+        var system = mockMe.Spec.GiveMe.The<ISystem>();
+        var mock = Mock.Get(system);
+
+        if (now is not null)
+        {
+            mock.Setup(c => c.Now).Returns(now.Value);
+        }
     }
 
     #endregion

--- a/src/blueprints/Do.Blueprints.Service.Application/ServiceSpecExtensions.cs
+++ b/src/blueprints/Do.Blueprints.Service.Application/ServiceSpecExtensions.cs
@@ -27,15 +27,15 @@ public static class ServiceSpecExtensions
         spec.Settings[key] = value;
     }
 
-    public static void TheSettings(this Mocker mockMe,
-        Dictionary<string, string>? settings = default,
+    internal static IConfiguration TheConfiguration(this Mocker mockMe, Dictionary<string, string> settings,
         Func<string, string>? defaultValue = default
     )
     {
-        settings ??= new Dictionary<string, string>();
         defaultValue ??= (key) => key.EndsWith("Url") ? "https://test.com?value" : "test value";
 
-        Mock.Get(mockMe.Spec.GiveMe.The<IConfiguration>())
+        var configuration = mockMe.Spec.GiveMe.The<IConfiguration>();
+
+        Mock.Get(configuration)
            .Setup(c => c.GetSection(It.IsAny<string>())).Returns((string key) =>
            {
                var mockSection = new Mock<IConfigurationSection>();
@@ -52,13 +52,15 @@ public static class ServiceSpecExtensions
 
                return mockSection.Object;
            });
+
+        return configuration;
     }
 
     #endregion
 
     #region System
 
-    public static void TheSystem(this Mocker mockMe,
+    public static ISystem TheSystem(this Mocker mockMe,
         DateTime? now = default
     )
     {
@@ -69,6 +71,8 @@ public static class ServiceSpecExtensions
         {
             mock.Setup(c => c.Now).Returns(now.Value);
         }
+
+        return system;
     }
 
     #endregion
@@ -170,7 +174,8 @@ public static class ServiceSpecExtensions
 
     #region String Extensions
 
-    public static string AString(this Stubber _) => "string";
+    public static string AString(this Stubber _,
+        string? value = default) => value ?? "string";
 
     #endregion
 }

--- a/src/blueprints/Do.Blueprints.Service.Application/ServiceSpecExtensions.cs
+++ b/src/blueprints/Do.Blueprints.Service.Application/ServiceSpecExtensions.cs
@@ -1,6 +1,8 @@
-﻿using Do.MockOverrider;
+﻿using Do.Core;
+using Do.MockOverrider;
 using Do.Testing;
 using Microsoft.Extensions.DependencyInjection;
+using Moq;
 using Shouldly;
 using System.Reflection;
 using System.Text.RegularExpressions;
@@ -9,6 +11,25 @@ namespace Do;
 
 public static class ServiceSpecExtensions
 {
+    #region Settings
+    
+    public static void TheSetting(this Mocker mocker, string key, string value)
+    {
+        ((ServiceSpec)mocker.Spec).Settings[key] = value;
+    } 
+
+    #endregion
+
+    #region System
+
+    public static void TheSystem(this Mocker mockMe, DateTime now)
+    {
+        Mock.Get(mockMe.Spec.GiveMe.The<ISystem>())
+           .Setup(c => c.Now).Returns(now);
+    } 
+
+    #endregion
+
     #region MockOverrider
 
     public static T The<T>(this Stubber _, params object?[] mockOverrides) where T : notnull =>
@@ -101,6 +122,12 @@ public static class ServiceSpecExtensions
     public static Guid AGuid(this Stubber _,
         string? guid = default
     ) => guid is null ? Guid.NewGuid() : Guid.Parse(guid);
+
+    #endregion
+
+    #region String Extensions
+
+    public static string AString(this Stubber _) => "string";
 
     #endregion
 }

--- a/src/blueprints/Do.Blueprints.Service.Application/Testing/DefaultMockFactory.cs
+++ b/src/blueprints/Do.Blueprints.Service.Application/Testing/DefaultMockFactory.cs
@@ -1,10 +1,11 @@
+using Microsoft.Extensions.DependencyInjection;
 using Moq;
 
 namespace Do.Testing;
 
 public class DefaultMockFactory : IMockFactory
 {
-    public virtual object Create(IServiceProvider serviceProvider, MockDescriptor mockDescriptor)
+    public virtual object Create(IServiceProvider _, MockDescriptor mockDescriptor)
     {
         var mockType = typeof(Mock<>).MakeGenericType(mockDescriptor.Type);
         var mockInstance = (Mock?)Activator.CreateInstance(mockType)

--- a/src/blueprints/Do.Blueprints.Service/Do.Blueprints.Service.csproj
+++ b/src/blueprints/Do.Blueprints.Service/Do.Blueprints.Service.csproj
@@ -13,6 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
   </ItemGroup>
 

--- a/unreleased.md
+++ b/unreleased.md
@@ -6,3 +6,9 @@
   an entity to be updated in a new transaction.
 - `ApplicationContext` `KeyNotFoundException` is now more informative.
 - Same `Layer` and `Feature` can no longer be added multiple times.
+- Mocked services which are singleton are now reset during unit test teardown
+- `IConfiguration`mock is now added and can be configured with helpers
+  provided from `ServiceSpec`
+- `ISystem`can now be configured with helpers provided from `ServiceSpec`
+
+


### PR DESCRIPTION
Enable test case scope mocking of singleton services

## Tasks

- [x] Reset singleton mocks after each test case

## Additional Tasks

- [x] Register an `IConfiguration` mock for testing
- [x] Add helpers for `Mock<IConfiguration>` setup
- [x] Add helpers for `Mock<ISystem>` setup
- [x] Add `GiveMe.AString()` helper
- [x] Add Configuration.Abstractions and Configuration.Binder packages to Do.Blueprints
