### PR TITLE
Issue / Scoped Service Helper

### DIFF
--- a/src/blueprints/Do.Blueprints.Service.Application/Business/BusinessExtensions.cs
+++ b/src/blueprints/Do.Blueprints.Service.Application/Business/BusinessExtensions.cs
@@ -13,4 +13,10 @@ public static class BusinessExtensions
         source.AddSingleton<Func<T>>(sp => () => sp.GetRequiredServiceUsingRequestServices<T>());
         source.AddTransient<T>();
     }
+
+    public static void AddScopedWithFactory<T>(this IServiceCollection source) where T : class
+    {
+        source.AddSingleton<Func<T>>(sp => () => sp.GetRequiredServiceUsingRequestServices<T>());
+        source.AddScoped<T>();
+    }
 }

--- a/src/blueprints/Do.Blueprints.Service.Application/ServiceSpecExtensions.cs
+++ b/src/blueprints/Do.Blueprints.Service.Application/ServiceSpecExtensions.cs
@@ -186,15 +186,21 @@ public static class ServiceSpecExtensions
 
     public static ISystem TheSystem(this Mocker mockMe,
         DateTime? now = default,
-        bool? passSomeTime = default
+        bool passSomeTime = false
     )
     {
         var system = mockMe.Spec.GiveMe.The<ISystem>();
         var mock = Mock.Get(system);
 
-        now ??= system.Now;
+        if (now is not null)
+        {
+            mock.Setup(c => c.Now).Returns(now.Value);
+        }
 
-        mock.Setup(c => c.Now).Returns(passSomeTime.GetValueOrDefault() ? now.Value : now.Value.AddSeconds(1));
+        if (passSomeTime)
+        {
+            mock.Setup(c => c.Now).Returns(system.Now.AddSeconds(1));
+        }
 
         return system;
     }

--- a/src/blueprints/Do.Blueprints.Service.Application/ServiceSpecExtensions.cs
+++ b/src/blueprints/Do.Blueprints.Service.Application/ServiceSpecExtensions.cs
@@ -12,6 +12,28 @@ namespace Do;
 
 public static class ServiceSpecExtensions
 {
+    #region DateTime
+
+    public static DateTime ADateTime(this Stubber _,
+        int year = 2023,
+        int month = 9,
+        int day = 17,
+        int hour = 13,
+        int minute = 29,
+        int second = 00
+    ) => new(year, month, day, hour, minute, second);
+
+    #endregion
+
+    #region Dictionary
+
+    public static Dictionary<string, string> ADictionary(this Stubber giveMe) => giveMe.ADictionary<string, string>();
+    public static Dictionary<TKey, TValue> ADictionary<TKey, TValue>(this Stubber _, params (TKey, TValue)[] pairs)
+        where TKey : notnull
+    => pairs.ToDictionary(pair => pair.Item1, pair => pair.Item2);
+
+    #endregion
+
     #region Entity
 
     public static void ShouldBeDeleted(this object @object) =>
@@ -148,11 +170,15 @@ public static class ServiceSpecExtensions
 
     #endregion
 
-    #region String Extensions
+    #region String
+
+    public static string AnEmail(this Stubber _) => "info@test.com";
 
     public static string AString(this Stubber _,
         string? value = default
     ) => value ?? "test string";
+
+    public static Guid ToGuid(this string source) => Guid.Parse(source);
 
     #endregion
 

--- a/src/blueprints/Do.Blueprints.Service.Application/ServiceSpecExtensions.cs
+++ b/src/blueprints/Do.Blueprints.Service.Application/ServiceSpecExtensions.cs
@@ -185,16 +185,16 @@ public static class ServiceSpecExtensions
     #region System
 
     public static ISystem TheSystem(this Mocker mockMe,
-        DateTime? now = default
+        DateTime? now = default,
+        bool? passSomeTime = default
     )
     {
         var system = mockMe.Spec.GiveMe.The<ISystem>();
         var mock = Mock.Get(system);
 
-        if (now is not null)
-        {
-            mock.Setup(c => c.Now).Returns(now.Value);
-        }
+        now ??= system.Now;
+
+        mock.Setup(c => c.Now).Returns(passSomeTime.GetValueOrDefault() ? now.Value : now.Value.AddSeconds(1));
 
         return system;
     }

--- a/unreleased.md
+++ b/unreleased.md
@@ -3,3 +3,9 @@
 ## Improvements
 
 - Added `ScopedWithFactory<T>()` helper for registering scoped services
+- Added new ServiceSpec extensions:
+  - `ADateTime` extension for `Stubber`
+  - `ADictionary` extensions for `Stubber`
+  - `AnEmail` extension for `Stubber`
+  - `ToGuid` extension for `string`
+- Added `passSomeTime` parameter for `Mocker.TheSystem` extension

--- a/unreleased.md
+++ b/unreleased.md
@@ -1,1 +1,5 @@
 # Unreleased
+
+## Improvements
+
+- Added `ScopedWithFactory<T>()` helper for registering scoped services


### PR DESCRIPTION
Add a helper for registering scoped services

## Tasks

- [x] Add `ScopedWithFactory` extensions to `IServiceCollection`

## Additional Tasks

- [x] Add `Stubber` extensions for `Dictionary` 
- [x] Add `Stubber` extension for `DateTime`
- [x] Add `Stubber` extensions for `string`
  - [x] `AnEmail`
  - [x] `ToGuid`
- [x] Add `passSomeTime` parameter to `TheSystem`