### PR TITLE
Issue / Include Stylecop in Packages

### DIFF
--- a/docs/release-notes/v0-3-2.md
+++ b/docs/release-notes/v0-3-2.md
@@ -22,4 +22,3 @@
 | ----------------------------------------------- | ----------- | ----------- |
 | Microsoft.Extensions.Configuration.Abstractions | new         | 6.0.0       |
 | Microsoft.Extensions.Configuration.Binder       | new         | 6.0.0       |
-| StyleCop.Analyzers.Unstable                     | new         | 1.2.0.507   |

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -30,9 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="..\..\..\stylecop.ruleset">
-      <CopyToOutputDirectory>true</CopyToOutputDirectory>
-    </Content>
+    <Content Include="..\..\..\stylecop.ruleset" />
   </ItemGroup>
 
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -29,4 +29,10 @@
     <None Include="..\..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="..\..\..\stylecop.ruleset">
+      <CopyToOutputDirectory>true</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -27,10 +27,7 @@
     <None Include="..\..\..\icon.png" Pack="true" PackagePath="\" />
     <None Include="..\..\..\LICENSE" Pack="true" PackagePath="\" />
     <None Include="..\..\..\README.md" Pack="true" PackagePath="\" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="..\..\..\stylecop.ruleset" />
+    <None Include="..\..\..\stylecop.ruleset" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/blueprints/Do.Blueprints.Service.Application/do-blueprints-service-application.targets
+++ b/src/blueprints/Do.Blueprints.Service.Application/do-blueprints-service-application.targets
@@ -8,4 +8,11 @@
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)../content/stylecop.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.507">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/src/blueprints/Do.Blueprints.Service.Application/do-blueprints-service-application.targets
+++ b/src/blueprints/Do.Blueprints.Service.Application/do-blueprints-service-application.targets
@@ -3,5 +3,9 @@
   <ItemGroup>
     <Using Include="Do" />
   </ItemGroup>
+  
+  <PropertyGroup>
+    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)../content/stylecop.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
 
 </Project>

--- a/src/blueprints/Do.Blueprints.Service.Application/do-blueprints-service-application.targets
+++ b/src/blueprints/Do.Blueprints.Service.Application/do-blueprints-service-application.targets
@@ -5,7 +5,7 @@
   </ItemGroup>
   
   <PropertyGroup>
-    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)../content/stylecop.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)../stylecop.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/blueprints/Do.Blueprints.Service/do-blueprints-service.targets
+++ b/src/blueprints/Do.Blueprints.Service/do-blueprints-service.targets
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)../content/stylecop.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)../stylecop.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/blueprints/Do.Blueprints.Service/do-blueprints-service.targets
+++ b/src/blueprints/Do.Blueprints.Service/do-blueprints-service.targets
@@ -9,4 +9,8 @@
     <Using Include="System.Threading.Tasks" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)../content/stylecop.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+
 </Project>

--- a/src/blueprints/Do.Blueprints.Service/do-blueprints-service.targets
+++ b/src/blueprints/Do.Blueprints.Service/do-blueprints-service.targets
@@ -13,4 +13,11 @@
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)../content/stylecop.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.507">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/src/core/Do.Architecture/do-architecture.targets
+++ b/src/core/Do.Architecture/do-architecture.targets
@@ -8,4 +8,11 @@
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)../content/stylecop.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.507">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/src/core/Do.Architecture/do-architecture.targets
+++ b/src/core/Do.Architecture/do-architecture.targets
@@ -5,7 +5,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)../content/stylecop.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)../stylecop.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/core/Do.Architecture/do-architecture.targets
+++ b/src/core/Do.Architecture/do-architecture.targets
@@ -1,5 +1,11 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
   <ItemGroup>
     <Using Include="Do" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)../content/stylecop.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+
 </Project>

--- a/unreleased.md
+++ b/unreleased.md
@@ -1,1 +1,11 @@
 # Unreleased
+
+## Improvements
+
+- All packages include `StyleCop` and a custom `stylecop.ruleset` now
+
+## Library Upgrades
+
+| Package                     | Old Version | New Version |
+| --------------------------- | ----------- | ----------- |
+| StyleCop.Analyzers.Unstable | new         | 1.2.0.507   |


### PR DESCRIPTION
Include stylecop.ruleset in nuget package

## Tasks

- [x] include stylecop.ruleset in nuget package as content

## Additional Tasks

- [x] access and use stylecop.ruleset from NuGet cache
- [x] local package tests