### PR TITLE
Issue / Document Project Namings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,21 @@ Collective. It is, and will always be, free and open source.
 - Don't use access modifier when they are default
   - ⛔ Wrong => `private int _id;`
   - ✅ Correct => `int _id;`
+- Use named arguments when calling methods with optional parameters
+  ```csharp
+  public void Method(string required
+      string? optional = default
+  )
+  { 
+    ... 
+  }
+
+  // ⛔ Wrong
+  service.Method("Required", "Optional");
+  // ✅ Correct
+  service.Method("Required", optional: "Optional");
+  ``` 
+- Use file scoped namespaces
 - Don't use `[TestFixture]` attribute, nunit runs tests without it anyway
 - Refer to [PrimaryConstructos](https://github.com/mouseless/learn-dotnet/tree/main/primary-constructor/README.md)
   for coding standards we enforce using `PrimaryConstructors`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,49 +16,6 @@ Collective. It is, and will always be, free and open source.
   - `/blueprints`: e2e test projects per blueprint package
   - `/core`: unit test projects per package
 
-## Naming Conventions
-
-- Use [Layer.Conventions](https://github.com/mouseless/do/tree/main/docs/architecture/layer.md) 
-  when adding a new layer
-- Use [Feature.Conventions](https://github.com/mouseless/do/tree/main/docs/architecture/feature.md) 
-  when adding a new feature or feature implementation
-- Use documentation heading names for text fixtures
-  - ⛔ Wrong => `AddExtensionTest`
-  - ✅ Correct => `AddingExtensions`
-- Use `Extensions` suffix for static extension classes
-
-## Coding Standards
-
-- Use file scoped namespaces
-- Use `_` prefix for private fields
-  - ⛔ Wrong => `int id;`
-  - ✅ Correct => `int _id;`
-- Don't use access modifier when they are default
-  - ⛔ Wrong => `private int _id;`
-  - ✅ Correct => `int _id;`  
-- Refer to [PrimaryConstructos](https://github.com/mouseless/learn-dotnet/tree/main/primary-constructor/README.md)
-  for coding standards we follow when using `PrimaryConstructors`.
-- Refer to [NullableUsage](https://github.com/mouseless/learn-dotnet/tree/main/nullable-usage/README.md)
-  for coding standards we follow when using `nullable` value and reference 
-  types.
-- Refer to [Stylecop.Analyzers](https://github.com/mouseless/learn-dotnet/tree/main/analyzers/README.md)
-  for coding standards we enforce using `Stylecop Analyzers`.
-- Use named arguments when calling methods with optional parameters
-  ```csharp
-  public void Method(string required
-      string? optional = default
-  )
-  { 
-    ... 
-  }
-
-  // ⛔ Wrong
-  service.Method("Required", "Optional");
-  // ✅ Correct
-  service.Method("Required", optional: "Optional");
-  ``` 
-- Don't use `[TestFixture]` attribute, nunit runs tests without it anyway
-
 ## Feature project conventions;
 
 - When there is a single implementation, it becomes `Do.{Feature}` and
@@ -79,3 +36,44 @@ Collective. It is, and will always be, free and open source.
   itself.
   - However, a feature implementation must always be published with the package
     name matching its own port.
+
+## Naming Conventions
+
+- Use [Layer.Conventions](https://github.com/mouseless/do/tree/main/docs/architecture/layer.md) 
+  when adding a new layer
+- Use [Feature.Conventions](https://github.com/mouseless/do/tree/main/docs/architecture/feature.md) 
+  when adding a new feature or feature implementation
+- Use documentation heading names for text fixtures
+  - ⛔ Wrong => `AddExtensionTest`
+  - ✅ Correct => `AddingExtensions`
+- Use `Extensions` suffix for static extension classes
+
+## Coding Standards
+
+- Use file scoped namespaces
+- Use `_` prefix for private fields
+  - ⛔ Wrong => `int id;`
+  - ✅ Correct => `int _id;`
+- Don't use access modifier when they are default
+  - ⛔ Wrong => `private int _id;`
+  - ✅ Correct => `int _id;`  
+- Use named arguments when calling methods with optional parameters
+  ```csharp
+  public void Method(string required
+      string? optional = default
+  )
+  // ⛔ Wrong
+  service.Method("Required", "Optional");
+  // ✅ Correct
+  service.Method("Required", optional: "Optional");
+  ``` 
+- Don't use `[TestFixture]` attribute, nunit runs tests without it anyway
+- Place static factory or helper methods at the top of before any instance 
+  members
+- Refer to [PrimaryConstructos](https://github.com/mouseless/learn-dotnet/tree/main/primary-constructor/README.md)
+  for coding standards we follow when using `PrimaryConstructors`.
+- Refer to [NullableUsage](https://github.com/mouseless/learn-dotnet/tree/main/nullable-usage/README.md)
+  for coding standards we follow when using `nullable` value and reference 
+  types.
+- Refer to [Stylecop.Analyzers](https://github.com/mouseless/learn-dotnet/tree/main/analyzers/README.md)
+  for coding standards we enforce using `Stylecop Analyzers`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,14 +16,33 @@ Collective. It is, and will always be, free and open source.
   - `/blueprints`: e2e test projects per blueprint package
   - `/core`: unit test projects per package
 
+## Naming Conventions
+
+- Use [Layer.Conventions](https://github.com/mouseless/do/tree/main/docs/architecture/layer.md) 
+  when adding a new layer
+- Use [Feature.Conventions](https://github.com/mouseless/do/tree/main/docs/architecture/feature.md) 
+  when adding a new feature or feature implementation
+- Use documentation heading names for text fixtures
+  - ⛔ Wrong => `AddExtensionTest`
+  - ✅ Correct => `AddingExtensions`
+- Use `Extensions` suffix for static extension classes
+
 ## Coding Standards
 
+- Use file scoped namespaces
 - Use `_` prefix for private fields
   - ⛔ Wrong => `int id;`
   - ✅ Correct => `int _id;`
 - Don't use access modifier when they are default
   - ⛔ Wrong => `private int _id;`
-  - ✅ Correct => `int _id;`
+  - ✅ Correct => `int _id;`  
+- Refer to [PrimaryConstructos](https://github.com/mouseless/learn-dotnet/tree/main/primary-constructor/README.md)
+  for coding standards we follow when using `PrimaryConstructors`.
+- Refer to [NullableUsage](https://github.com/mouseless/learn-dotnet/tree/main/nullable-usage/README.md)
+  for coding standards we follow when using `nullable` value and reference 
+  types.
+- Refer to [Stylecop.Analyzers](https://github.com/mouseless/learn-dotnet/tree/main/analyzers/README.md)
+  for coding standards we enforce using `Stylecop Analyzers`.
 - Use named arguments when calling methods with optional parameters
   ```csharp
   public void Method(string required
@@ -38,24 +57,9 @@ Collective. It is, and will always be, free and open source.
   // ✅ Correct
   service.Method("Required", optional: "Optional");
   ``` 
-- Use file scoped namespaces
 - Don't use `[TestFixture]` attribute, nunit runs tests without it anyway
-- Refer to [PrimaryConstructos](https://github.com/mouseless/learn-dotnet/tree/main/primary-constructor/README.md)
-  for coding standards we follow when using `PrimaryConstructors`.
-- Refer to [NullableUsage](https://github.com/mouseless/learn-dotnet/tree/main/nullable-usage/README.md)
-  for coding standards we follow when using `nullable` value and reference 
-  types.
-- Refer to [Stylecop.Analyzers](https://github.com/mouseless/learn-dotnet/tree/main/analyzers/README.md)
-  for coding standards we enforce using `Stylecop Analyzers`.
 
-## Naming Conventions
-
-- Use documentation heading names for text fixtures
-  - ⛔ Wrong => `AddExtensionTest`
-  - ✅ Correct => `AddingExtensions`
-- Use `Extensions` suffix for static extension classes
-
-## Feature project naming conventions;
+## Feature project conventions;
 
 - When there is a single implementation, it becomes `Do.{Feature}` and
   `Do.{Feature}.{Implementation}`, and the configurator is embedded in the
@@ -66,12 +70,12 @@ Collective. It is, and will always be, free and open source.
 - `Do.csproj` contains ports such as `Logging`, `Setting`, etc. that will be
   used in all projects (but `do` cannot be released, maybe it could be
   `do-core` :thinking:).
-- `Do.Configuration.csproj` contains the configurator classes and feature
+- `Do.Configuration.csproj` contains configurator classes and feature
   interfaces when a second implementation of these ports are introduced.
 - Sometimes a layer and feature will provide meaningful functionality when they
-  coexist, such as `HttpClient` and `Communication`. In this case, layer can
+  coexist, such as `HttpClient` and `Communication`. In this case, a layer can
   be bundled with the feature and can be published in a single package like 
-  `Do.Communication`, meaning the layer can come from a package not named after 
+  `Do.Communication`, meaning a layer can come from a package not named after 
   itself.
   - However, a feature implementation must always be published with the package
     name matching its own port.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,9 +41,10 @@ Collective. It is, and will always be, free and open source.
 - Use file scoped namespaces
 - Don't use `[TestFixture]` attribute, nunit runs tests without it anyway
 - Refer to [PrimaryConstructos](https://github.com/mouseless/learn-dotnet/tree/main/primary-constructor/README.md)
-  for coding standards we enforce using `PrimaryConstructors`.
+  for coding standards we follow when using `PrimaryConstructors`.
 - Refer to [NullableUsage](https://github.com/mouseless/learn-dotnet/tree/main/nullable-usage/README.md)
-  for coding standards we enforce using `nullable` value and reference types.
+  for coding standards we follow when using `nullable` value and reference 
+  types.
 - Refer to [Stylecop.Analyzers](https://github.com/mouseless/learn-dotnet/tree/main/analyzers/README.md)
   for coding standards we enforce using `Stylecop Analyzers`.
 
@@ -53,3 +54,24 @@ Collective. It is, and will always be, free and open source.
   - ⛔ Wrong => `AddExtensionTest`
   - ✅ Correct => `AddingExtensions`
 - Use `Extensions` suffix for static extension classes
+
+## Feature project naming conventions;
+
+- When there is a single implementation, it becomes `Do.{Feature}` and
+  `Do.{Feature}.{Implementation}`, and the configurator is embedded in the
+  single implementation project.
+- When there are multiple implementations of a feature, the configurator class
+  is moved to `Do.{Feature}.Configuration` (or `.Base` :thinking:), and all
+  implementations will depend on this config project.
+- `Do.csproj` contains ports such as `Logging`, `Setting`, etc. that will be
+  used in all projects (but `do` cannot be released, maybe it could be
+  `do-core` :thinking:).
+- `Do.Configuration.csproj` contains the configurator classes and feature
+  interfaces when a second implementation of these ports are introduced.
+- Sometimes a layer and feature will provide meaningful functionality when they
+  coexist, such as `HttpClient` and `Communication`. In this case, layer can
+  be bundled with the feature and can be published in a single package like 
+  `Do.Communication`, meaning the layer can come from a package not named after 
+  itself.
+  - However, a feature implementation must always be published with the package
+    name matching its own port.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,10 @@ Collective. It is, and will always be, free and open source.
   - ⛔ Wrong => `private int _id;`
   - ✅ Correct => `int _id;`
 - Don't use `[TestFixture]` attribute, nunit runs tests without it anyway
+- Refer to [PrimaryConstructos](https://github.com/mouseless/learn-dotnet/tree/main/primary-constructor/README.md)
+  for coding standards we enforce using `PrimaryConstructors`.
+- Refer to [NullableUsage](https://github.com/mouseless/learn-dotnet/tree/main/nullable-usage/README.md)
+  for coding standards we enforce using `nullable` value and reference types.
 - Refer to [Stylecop.Analyzers](https://github.com/mouseless/learn-dotnet/tree/main/analyzers/README.md)
   for coding standards we enforce using `Stylecop Analyzers`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,8 @@ Collective. It is, and will always be, free and open source.
 - `/samples`: sample projects are here. Each project should be in its own
   folder
 - `/src`: all source code that we ship as nuget packages
+  - `/tools`: CLI tools
+  - `/extensions`: features and/or layers
   - `/blueprints`: blueprint packages
   - `/core`: core packages that every type of project will have a reference to
 - `/test`: test automation projects


### PR DESCRIPTION
Document project naming conventions for layers and features 

## Tasks

- [x] Add feature project naming conventions in `CONTRIBUTING.md`

## Additional Tasks

- [x] Edit `Coding Standarts` section to include current coding style requirements
