### PR TITLE
Issue / Code Generation / Document Layer to Layer Dependency

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -39,7 +39,7 @@ architecture.
 
 > :bulb:
 >
-> Layers are named after the domain of their technology.
+> Layers are named after the concept of their technology.
 
 ```mermaid
 flowchart LR
@@ -141,18 +141,18 @@ flowchart TB
 
   subgraph Features
     subgraph Abstraction
-      A(Api)
+      A(Authentication)
       Db(Database)
     end
 
     subgraph Implementation
-      AR(Api.Rest)
+      AF(Authentication.FixedToken)
       DbM(Database.MySql)
     end
   end
 
-  HS -.configured by.-> AR
-  A --implemented by--> AR
+  HS -.configured by.-> AF
+  A --implemented by--> AF
   D -.uses.-> A
   D -.uses.-> Db
   Db --implemented by--> DbM

--- a/docs/architecture/application.md
+++ b/docs/architecture/application.md
@@ -106,8 +106,9 @@ Forge.New
     .Run();
 ```
 
-Application runs in phases provided by its layers. For example an `HttpLayer` 
-uses ASP.NET Core application typically runs in three phases;
+Application runs in phases provided by its layers. For example 
+`HttpServerLayer` uses ASP.NET Core to build a web application which typically
+runs in three phases;
 
 ```mermaid
 flowchart TB

--- a/docs/architecture/application.md
+++ b/docs/architecture/application.md
@@ -101,13 +101,13 @@ To run an application you need to call `Run()` method after forging it.
 Forge.New
     .Application(app =>
     {
-        app.Layers.AddHttpServer();
+        ...
     })
     .Run();
 ```
 
-Application runs in phases provided by its layers. For example an ASP.NET Core
-application typically runs in three phases;
+Application runs in phases provided by its layers. For example an `HttpLayer` 
+uses ASP.NET Core application typically runs in three phases;
 
 ```mermaid
 flowchart TB

--- a/docs/architecture/application.md
+++ b/docs/architecture/application.md
@@ -124,7 +124,9 @@ above example, `HttpServerLayer` (ASP.NET Core) introduced these three phases.
 At the beginning of each phase, application initializes it by providing an
 `ApplicationContext` instance. This way each phase can add/get certain objects
 to/from the context, such as `IServiceCollection`, `IMiddlewareCollection`,
-`IEndpointRouteBuilder` etc.
+`IEndpointRouteBuilder` etc. 
+Refer to [Readiness via Dependencies](./layer.md#readiness-via-dependencies) 
+for more details.
 
 > :warning:
 >

--- a/docs/architecture/layer.md
+++ b/docs/architecture/layer.md
@@ -154,6 +154,38 @@ public class Build : PhaseBase<WebApplicationBuilder>
 > dependency in `ApplicationContext`. For more information
 > [Running an Application](../architecture/application.md#running-an-application)
 
+Phases can also define context dependencies from other phase artifacts. For 
+example `HttpServerLayer.Build` phase can require `IServiceCollection` which 
+will be provided during `DependencyInjectionLayer.AddServices` phase. 
+
+```csharp
+// DependencyInjectionLayer
+public class AddServices(IServiceCollection _services)
+    : PhaseBase(PhaseOrder.Early)
+{
+    protected override void Initialize()
+    {
+        Context.Add(_services);
+    }
+}
+
+// HttpServerLayer
+public class Build()
+    : PhaseBase<WebApplicationBuilder, IServiceCollection>(PhaseOrder.Latest)
+{
+    protected override void Initialize(WebApplicationBuilder build, IServiceCollection services)
+    {
+        ...
+    }
+}
+```
+
+> :warning:
+>
+> This type of artifact requirement will create a dependency between phases 
+> which results to a layer to layer dependency. In the above example `Build`
+> phase will never execute unless `DependencyLayer` is added to the application
+
 ### Order of a Phase
 
 `PhaseBase` classes has `order` parameter in their constructors. Default order

--- a/docs/blueprints/service.md
+++ b/docs/blueprints/service.md
@@ -15,7 +15,7 @@ To create an application from this blueprint, use `Service()` extension of
 ```csharp
 Forge.New
     .Service(
-        business: c => c.MyBusiness(),
+        business: c => c.Default(assemblies: [...]),
         database: c => c.Sqlite()
     )
     .Run();
@@ -48,7 +48,7 @@ Features with default options are;
 | Database           | Sqlite        | InMemory        | Yes      |
 | Documentation      | Default       |                 |          |
 | Exception Handling | Default       |                 |          |
-| Greeting           | Hello World   |                 |          |
+| Greeting           | Swagger       |                 |          |
 | Logging            | Request       |                 |          |
 | Mocking Overrider  |               | First Interface |          |
 | Orm                | Default       | Default         |          |

--- a/docs/layers/rest-api.md
+++ b/docs/layers/rest-api.md
@@ -9,8 +9,8 @@ app.Layers.AddRestApi();
 ## Configuration Targets
 
 This layer provides `IApplicationPartCollection` for registering necessary
-application parts, `SwaggerGenOptions`, `SwaggerOptions` and `SwaggerUIOptions`
-for configuring `Swagger` behavior.
+application parts, `MvcNewtonsoftJsonOptions` `SwaggerGenOptions`, 
+`SwaggerOptions` and `SwaggerUIOptions` for configuring `Swagger` behavior.
 
 ### `IApplicationPartCollection`
 
@@ -21,6 +21,17 @@ configurator.ConfigureApplicationParts(applicationParts =>
 {
     ...
 });
+```
+
+### `MvcNewtonsoftJsonOptions``
+
+This target is provided in `AddServices` phase. To configure it in a feature;
+
+```csharp
+ configurator.ConfigureMvcNewtonsoftJsonOptions(options =>
+ {
+     ...
+ });
 ```
 
 ### `SwaggerGenOptions`

--- a/docs/layers/rest-api.md
+++ b/docs/layers/rest-api.md
@@ -9,7 +9,7 @@ app.Layers.AddRestApi();
 ## Configuration Targets
 
 This layer provides `IApplicationPartCollection` for registering necessary
-application parts, `MvcNewtonsoftJsonOptions` `SwaggerGenOptions`, 
+application parts, `List<JsonConverter>` `SwaggerGenOptions`, 
 `SwaggerOptions` and `SwaggerUIOptions` for configuring `Swagger` behavior.
 
 ### `IApplicationPartCollection`
@@ -23,12 +23,12 @@ configurator.ConfigureApplicationParts(applicationParts =>
 });
 ```
 
-### `MvcNewtonsoftJsonOptions``
+### `List<JsonConverter>`
 
 This target is provided in `AddServices` phase. To configure it in a feature;
 
 ```csharp
- configurator.ConfigureMvcNewtonsoftJsonOptions(options =>
+ configurator.ConfigureJsonConverters(converters =>
  {
      ...
  });

--- a/docs/layers/rest-api.md
+++ b/docs/layers/rest-api.md
@@ -9,7 +9,7 @@ app.Layers.AddRestApi();
 ## Configuration Targets
 
 This layer provides `IApplicationPartCollection` for registering necessary
-application parts, `List<JsonConverter>` `SwaggerGenOptions`, 
+application parts, `MvcNewtonsoftJsonOptions` `SwaggerGenOptions`, 
 `SwaggerOptions` and `SwaggerUIOptions` for configuring `Swagger` behavior.
 
 ### `IApplicationPartCollection`
@@ -23,12 +23,12 @@ configurator.ConfigureApplicationParts(applicationParts =>
 });
 ```
 
-### `List<JsonConverter>`
+### `MvcNewtonsoftJsonOptions`
 
 This target is provided in `AddServices` phase. To configure it in a feature;
 
 ```csharp
- configurator.ConfigureJsonConverters(converters =>
+ configurator.ConfigureMvcNewtonsoftJsonOptions(options =>
  {
      ...
  });

--- a/src/blueprints/Do.Blueprints.Service.Application/Business/Default/DefaultBusinessFeature.cs
+++ b/src/blueprints/Do.Blueprints.Service.Application/Business/Default/DefaultBusinessFeature.cs
@@ -1,6 +1,8 @@
 ﻿using Do.Architecture;
 using Do.Domain.Model;
 using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
 using System.Reflection;
 
 namespace Do.Business.Default;
@@ -83,6 +85,11 @@ public class DefaultBusinessFeature(List<Assembly> _domainAssemblies)
                     });
                 }
             }
+        });
+
+        configurator.ConfigureMvcNewtonsoftJsonOptions(options =>
+        {
+            options.SerializerSettings.Converters.Add(new StringEnumConverter(new CamelCaseNamingStrategy()));
         });
     }
 }

--- a/src/blueprints/Do.Blueprints.Service.Application/RestApi/RestApiExtensions.cs
+++ b/src/blueprints/Do.Blueprints.Service.Application/RestApi/RestApiExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Do.Architecture;
 using Do.RestApi;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Swashbuckle.AspNetCore.Swagger;
 using Swashbuckle.AspNetCore.SwaggerGen;
@@ -12,6 +13,7 @@ public static class RestApiExtensions
     public static void AddRestApi(this IList<ILayer> source) => source.Add(new RestApiLayer());
 
     public static void ConfigureApplicationParts(this LayerConfigurator source, Action<IApplicationPartCollection> configuration) => source.Configure(configuration);
+    public static void ConfigureMvcNewtonsoftJsonOptions(this LayerConfigurator source, Action<MvcNewtonsoftJsonOptions> configuration) => source.Configure(configuration);
     public static void ConfigureSwaggerGenOptions(this LayerConfigurator source, Action<SwaggerGenOptions> configuration) => source.Configure(configuration);
     public static void ConfigureSwaggerOptions(this LayerConfigurator source, Action<SwaggerOptions> configuration) => source.Configure(configuration);
     public static void ConfigureSwaggerUIOptions(this LayerConfigurator source, Action<SwaggerUIOptions> configuration) => source.Configure(configuration);

--- a/src/blueprints/Do.Blueprints.Service.Application/RestApi/RestApiExtensions.cs
+++ b/src/blueprints/Do.Blueprints.Service.Application/RestApi/RestApiExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using Do.Architecture;
 using Do.RestApi;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
 using Swashbuckle.AspNetCore.Swagger;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using Swashbuckle.AspNetCore.SwaggerUI;
@@ -13,7 +13,7 @@ public static class RestApiExtensions
     public static void AddRestApi(this IList<ILayer> source) => source.Add(new RestApiLayer());
 
     public static void ConfigureApplicationParts(this LayerConfigurator source, Action<IApplicationPartCollection> configuration) => source.Configure(configuration);
-    public static void ConfigureMvcNewtonsoftJsonOptions(this LayerConfigurator source, Action<MvcNewtonsoftJsonOptions> configuration) => source.Configure(configuration);
+    public static void ConfigureJsonConverters(this LayerConfigurator source, Action<List<JsonConverter>> configuration) => source.Configure(configuration);
     public static void ConfigureSwaggerGenOptions(this LayerConfigurator source, Action<SwaggerGenOptions> configuration) => source.Configure(configuration);
     public static void ConfigureSwaggerOptions(this LayerConfigurator source, Action<SwaggerOptions> configuration) => source.Configure(configuration);
     public static void ConfigureSwaggerUIOptions(this LayerConfigurator source, Action<SwaggerUIOptions> configuration) => source.Configure(configuration);

--- a/src/blueprints/Do.Blueprints.Service.Application/RestApi/RestApiExtensions.cs
+++ b/src/blueprints/Do.Blueprints.Service.Application/RestApi/RestApiExtensions.cs
@@ -1,7 +1,8 @@
 ﻿using Do.Architecture;
 using Do.RestApi;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
-using Newtonsoft.Json;
+using Microsoft.Extensions.Options;
 using Swashbuckle.AspNetCore.Swagger;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using Swashbuckle.AspNetCore.SwaggerUI;
@@ -13,7 +14,7 @@ public static class RestApiExtensions
     public static void AddRestApi(this IList<ILayer> source) => source.Add(new RestApiLayer());
 
     public static void ConfigureApplicationParts(this LayerConfigurator source, Action<IApplicationPartCollection> configuration) => source.Configure(configuration);
-    public static void ConfigureJsonConverters(this LayerConfigurator source, Action<List<JsonConverter>> configuration) => source.Configure(configuration);
+    public static void ConfigureMvcNewtonsoftJsonOptions(this LayerConfigurator source, Action<MvcNewtonsoftJsonOptions> configuration) => source.Configure(configuration);
     public static void ConfigureSwaggerGenOptions(this LayerConfigurator source, Action<SwaggerGenOptions> configuration) => source.Configure(configuration);
     public static void ConfigureSwaggerOptions(this LayerConfigurator source, Action<SwaggerOptions> configuration) => source.Configure(configuration);
     public static void ConfigureSwaggerUIOptions(this LayerConfigurator source, Action<SwaggerUIOptions> configuration) => source.Configure(configuration);
@@ -24,6 +25,15 @@ public static class RestApiExtensions
         {
             source.AddApplicationPart(applicationPart.Assembly);
         }
+
+        return source;
+    }
+
+    internal static IMvcBuilder AddNewtonsoftJson(this IMvcBuilder source, MvcNewtonsoftJsonOptions options)
+    {
+        source.AddNewtonsoftJson();
+        source.Services.AddOptions();
+        source.Services.AddSingleton<IOptions<MvcNewtonsoftJsonOptions>>(sp => new OptionsWrapper<MvcNewtonsoftJsonOptions>(options));
 
         return source;
     }

--- a/src/blueprints/Do.Blueprints.Service.Application/RestApi/RestApiLayer.cs
+++ b/src/blueprints/Do.Blueprints.Service.Application/RestApi/RestApiLayer.cs
@@ -1,7 +1,7 @@
 ﻿using Do.Architecture;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
 using Swashbuckle.AspNetCore.Swagger;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using Swashbuckle.AspNetCore.SwaggerUI;
@@ -14,7 +14,7 @@ namespace Do.RestApi;
 public class RestApiLayer : LayerBase<AddServices, Build>
 {
     readonly IApplicationPartCollection _applicationParts = new ApplicationPartCollection();
-    readonly MvcNewtonsoftJsonOptions _mvcNewtonsoftJsonOptions = new();
+    readonly List<JsonConverter> _jsonConverters = [];
     readonly SwaggerGenOptions _swaggerGenOptions = new();
     readonly SwaggerOptions _swaggerOptions = new();
     readonly SwaggerUIOptions _swaggerUIOptions = new();
@@ -29,12 +29,12 @@ public class RestApiLayer : LayerBase<AddServices, Build>
 
         return phase.CreateContextBuilder()
             .Add(_applicationParts)
-            .Add(_mvcNewtonsoftJsonOptions)
+            .Add(_jsonConverters)
             .Add(_swaggerGenOptions)
             .OnDispose(() =>
             {
                 services.AddControllers()
-                    .AddNewtonsoftJson(options => options = _mvcNewtonsoftJsonOptions)
+                    .AddNewtonsoftJson(options => options.SerializerSettings.Converters = _jsonConverters)
                     .AddApplicationParts(_applicationParts);
                 services.ConfigureSwaggerGen(config =>
                 {

--- a/src/blueprints/Do.Blueprints.Service.Application/RestApi/RestApiLayer.cs
+++ b/src/blueprints/Do.Blueprints.Service.Application/RestApi/RestApiLayer.cs
@@ -1,8 +1,7 @@
 ﻿using Do.Architecture;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
-using Newtonsoft.Json.Converters;
-using Newtonsoft.Json.Serialization;
 using Swashbuckle.AspNetCore.Swagger;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using Swashbuckle.AspNetCore.SwaggerUI;
@@ -15,6 +14,7 @@ namespace Do.RestApi;
 public class RestApiLayer : LayerBase<AddServices, Build>
 {
     readonly IApplicationPartCollection _applicationParts = new ApplicationPartCollection();
+    readonly MvcNewtonsoftJsonOptions _mvcNewtonsoftJsonOptions = new();
     readonly SwaggerGenOptions _swaggerGenOptions = new();
     readonly SwaggerOptions _swaggerOptions = new();
     readonly SwaggerUIOptions _swaggerUIOptions = new();
@@ -29,13 +29,12 @@ public class RestApiLayer : LayerBase<AddServices, Build>
 
         return phase.CreateContextBuilder()
             .Add(_applicationParts)
+            .Add(_mvcNewtonsoftJsonOptions)
             .Add(_swaggerGenOptions)
             .OnDispose(() =>
             {
                 services.AddControllers()
-                    .AddNewtonsoftJson(opts =>
-                        opts.SerializerSettings.Converters.Add(new StringEnumConverter(new CamelCaseNamingStrategy()))
-                    )
+                    .AddNewtonsoftJson(options => options = _mvcNewtonsoftJsonOptions)
                     .AddApplicationParts(_applicationParts);
                 services.ConfigureSwaggerGen(config =>
                 {

--- a/src/blueprints/Do.Blueprints.Service.Application/RestApi/RestApiLayer.cs
+++ b/src/blueprints/Do.Blueprints.Service.Application/RestApi/RestApiLayer.cs
@@ -1,7 +1,7 @@
 ﻿using Do.Architecture;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
-using Newtonsoft.Json;
 using Swashbuckle.AspNetCore.Swagger;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using Swashbuckle.AspNetCore.SwaggerUI;
@@ -14,7 +14,7 @@ namespace Do.RestApi;
 public class RestApiLayer : LayerBase<AddServices, Build>
 {
     readonly IApplicationPartCollection _applicationParts = new ApplicationPartCollection();
-    readonly List<JsonConverter> _jsonConverters = [];
+    readonly MvcNewtonsoftJsonOptions _mvcNewtonsoftJsonOptions = [];
     readonly SwaggerGenOptions _swaggerGenOptions = new();
     readonly SwaggerOptions _swaggerOptions = new();
     readonly SwaggerUIOptions _swaggerUIOptions = new();
@@ -29,12 +29,12 @@ public class RestApiLayer : LayerBase<AddServices, Build>
 
         return phase.CreateContextBuilder()
             .Add(_applicationParts)
-            .Add(_jsonConverters)
+            .Add(_mvcNewtonsoftJsonOptions)
             .Add(_swaggerGenOptions)
             .OnDispose(() =>
             {
                 services.AddControllers()
-                    .AddNewtonsoftJson(options => options.SerializerSettings.Converters = _jsonConverters)
+                    .AddNewtonsoftJson(_mvcNewtonsoftJsonOptions)
                     .AddApplicationParts(_applicationParts);
                 services.ConfigureSwaggerGen(config =>
                 {

--- a/test/blueprints/Do.Test.Blueprints.Service.Application/ConfigurationOverrider/ConfigurationOverriderFeature.cs
+++ b/test/blueprints/Do.Test.Blueprints.Service.Application/ConfigurationOverrider/ConfigurationOverriderFeature.cs
@@ -1,8 +1,6 @@
 ﻿using Do.Architecture;
 using Do.Authentication.FixedToken;
 using Microsoft.OpenApi.Models;
-using Newtonsoft.Json.Converters;
-using Newtonsoft.Json.Serialization;
 
 namespace Do.Test.ConfigurationOverrider;
 
@@ -55,11 +53,6 @@ public class ConfigurationOverriderFeature : IFeature
         configurator.ConfigureApplicationParts(applicationParts =>
         {
             applicationParts.Add(new(configurator.Context.GetGeneratedAssembly("Controllers")));
-        });
-
-        configurator.ConfigureMvcNewtonsoftJsonOptions(options =>
-        {
-            options.SerializerSettings.Converters.Add(new StringEnumConverter(new CamelCaseNamingStrategy()));
         });
     }
 }

--- a/test/blueprints/Do.Test.Blueprints.Service.Application/ConfigurationOverrider/ConfigurationOverriderFeature.cs
+++ b/test/blueprints/Do.Test.Blueprints.Service.Application/ConfigurationOverrider/ConfigurationOverriderFeature.cs
@@ -57,9 +57,9 @@ public class ConfigurationOverriderFeature : IFeature
             applicationParts.Add(new(configurator.Context.GetGeneratedAssembly("Controllers")));
         });
 
-        configurator.ConfigureMvcNewtonsoftJsonOptions(options =>
+        configurator.ConfigureJsonConverters(converters =>
         {
-            options.SerializerSettings.Converters.Add(new StringEnumConverter(new CamelCaseNamingStrategy()));
+            converters.Add(new StringEnumConverter(new CamelCaseNamingStrategy()));
         });
     }
 }

--- a/test/blueprints/Do.Test.Blueprints.Service.Application/ConfigurationOverrider/ConfigurationOverriderFeature.cs
+++ b/test/blueprints/Do.Test.Blueprints.Service.Application/ConfigurationOverrider/ConfigurationOverriderFeature.cs
@@ -57,9 +57,9 @@ public class ConfigurationOverriderFeature : IFeature
             applicationParts.Add(new(configurator.Context.GetGeneratedAssembly("Controllers")));
         });
 
-        configurator.ConfigureJsonConverters(converters =>
+        configurator.ConfigureMvcNewtonsoftJsonOptions(options =>
         {
-            converters.Add(new StringEnumConverter(new CamelCaseNamingStrategy()));
+            options.SerializerSettings.Converters.Add(new StringEnumConverter(new CamelCaseNamingStrategy()));
         });
     }
 }

--- a/test/blueprints/Do.Test.Blueprints.Service.Application/ConfigurationOverrider/ConfigurationOverriderFeature.cs
+++ b/test/blueprints/Do.Test.Blueprints.Service.Application/ConfigurationOverrider/ConfigurationOverriderFeature.cs
@@ -1,6 +1,8 @@
 ﻿using Do.Architecture;
 using Do.Authentication.FixedToken;
 using Microsoft.OpenApi.Models;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
 
 namespace Do.Test.ConfigurationOverrider;
 
@@ -53,6 +55,11 @@ public class ConfigurationOverriderFeature : IFeature
         configurator.ConfigureApplicationParts(applicationParts =>
         {
             applicationParts.Add(new(configurator.Context.GetGeneratedAssembly("Controllers")));
+        });
+
+        configurator.ConfigureMvcNewtonsoftJsonOptions(options =>
+        {
+            options.SerializerSettings.Converters.Add(new StringEnumConverter(new CamelCaseNamingStrategy()));
         });
     }
 }

--- a/unreleased.md
+++ b/unreleased.md
@@ -17,6 +17,7 @@
 - `CanReturn()` helper is added for `MethodModel` which loops through all
   overloads and compares return types for given `TypeModel`
     - Generic `Task` return types are also supported
+- `MvcNewtonsoftJsonOptions` is added to `RestApiLayer` as configuration target 
 
 ## Bugfixes
 


### PR DESCRIPTION
Update documentation for layers using other layers phase artifacts 

## Tasks

- [x] Document layer to layer dependency
  - use its configuration api through application context, e.g., `IServiceCollection`, `WebApplication` etc.

## Additional Tasks

- [x] docs issues
  - service blueprints still says
    - `c.MyBusiness()` for business feature config, but we have
      `c.Default<MyClass>()` now
  - `Hello World` for greeting default, but we've removed it
- [x] `CamelCaseNamingStrategy` is an opinion, provide this setting in a (new or
  existing) configuration target and move it into a feature
