### PR TITLE
Issue / Unwanted Api Services

### DIFF
--- a/unreleased.md
+++ b/unreleased.md
@@ -6,3 +6,4 @@
   as `FromBody` without generating a request class
 - Only concrete classes are now included in `EntityExtensionViaComposition` and
  `EntitySubclassViaComposition` coding style features
+- Transients with non api input parameters are now not rendered as api service


### PR DESCRIPTION
Transients with a non api input initializer parameter should not be an api
service. E.g., a transient with a public `With` method that has `Func<>`
parameter should not be marked as api service.

## Tasks

- [ ] ...

## Additional Tasks

- [ ] order actions in swagger
- [ ] add `Create` as an alias to `Add`
- [ ] don't render empty controllers