### PR TITLE
Issue / Lock Entity

### DIFF
--- a/src/blueprints/Do.Blueprints.Service.Application/Orm/EntityContext.cs
+++ b/src/blueprints/Do.Blueprints.Service.Application/Orm/EntityContext.cs
@@ -1,4 +1,4 @@
-﻿using ISession = NHibernate.ISession;
+﻿using NHibernate;
 
 namespace Do.Orm;
 
@@ -15,5 +15,10 @@ public class EntityContext<TEntity>(ISession _session)
     public void Delete(TEntity entity)
     {
         _session.Delete(entity);
+    }
+
+    public void Lock(TEntity entity)
+    {
+        _session.Refresh(entity, LockMode.Upgrade);
     }
 }

--- a/src/blueprints/Do.Blueprints.Service/Orm/IEntityContext.cs
+++ b/src/blueprints/Do.Blueprints.Service/Orm/IEntityContext.cs
@@ -4,4 +4,5 @@ public interface IEntityContext<TEntity>
 {
     TEntity Insert(TEntity entity);
     void Delete(TEntity entity);
+    void Lock(TEntity entity);
 }

--- a/test/blueprints/Do.Test.Blueprints.Service.Application/Program.cs
+++ b/test/blueprints/Do.Test.Blueprints.Service.Application/Program.cs
@@ -9,6 +9,7 @@ Forge.New
                 {
                     tokens.Add("Jane", claims: ["User", "BaseA", "BaseB"]);
                     tokens.Add("John", claims: ["User", "Admin", "BaseA", "BaseB"]);
+                    tokens.Add("Postman", claims: ["User", "Admin", "BaseA", "BaseB"]);
 
                     tokens.Add("Authenticated", claims: []);
                     tokens.Add("BaseClaims", claims: ["BaseA", "BaseB"]);

--- a/test/blueprints/Do.Test.Blueprints.Service.Application/appsettings.json
+++ b/test/blueprints/Do.Test.Blueprints.Service.Application/appsettings.json
@@ -1,8 +1,9 @@
 {
     "Authentication": {
         "FixedBearerToken": {
-            "Jane": "11111111111111111111111111111111",
-            "John": "22222222222222222222222222222222",
+            "Jane": "token-jane",
+            "John": "token-john",
+            "Postman": "token-postman",
 
             "Authenticated": "token-authenticated",
             "BaseClaims": "token-base-claims",

--- a/test/blueprints/Do.Test.Blueprints.Service.Test/Authentication/AddingParametersToFormPost.cs
+++ b/test/blueprints/Do.Test.Blueprints.Service.Test/Authentication/AddingParametersToFormPost.cs
@@ -13,7 +13,7 @@ public class AddingParametersToFormPost : TestServiceNfr
         {
             ["value"] = "value",
             ["additional"] = "additional",
-            ["hash"] = "ph0dPl9pFZdlrAq92u8NmuOHyMVus/pJQ0zNMEuej5A=" // valueadditional11111111111111111111111111111111 -sha256-> a61d1d3e5f69159765ac0abddaef0d9ae387c8c56eb3fa49434ccd304b9e8f90
+            ["hash"] = "LqGNbYhL3cCp5vNClVJ3I7D6kCe7rSnb/Tzhp/tV2As=" // valueadditionaltoken-jane -sha256-> 2ea18d6d884bddc0a9e6f34295527723b0fa9027bbad29dbfd3ce1a7fb55d80b
         };
 
         var response = await Client.PostAsync("authentication-samples/form-post-authenticate", new FormUrlEncodedContent(form));

--- a/test/blueprints/Do.Test.Blueprints.Service.Test/HttpServer/ConfiguringMultipleAuthenticationHandlers.cs
+++ b/test/blueprints/Do.Test.Blueprints.Service.Test/HttpServer/ConfiguringMultipleAuthenticationHandlers.cs
@@ -5,7 +5,7 @@ namespace Do.Test.HttpServer;
 
 public class ConfiguringMultipleAuthenticationHandlers : TestServiceNfr
 {
-    [TestCase("Authorization", "11111111111111111111111111111111", "FixedBearerToken")]
+    [TestCase("Authorization", "token-jane", "FixedBearerToken")]
     [TestCase("X-Api-Key", "apikey", "ApiKey")]
     public async Task Request_can_be_forwarded_to_available_handlers(string header, string value, string authenticationType)
     {

--- a/test/blueprints/Do.Test.Blueprints.Service/Orm/Entity.cs
+++ b/test/blueprints/Do.Test.Blueprints.Service/Orm/Entity.cs
@@ -107,6 +107,8 @@ public class Entity(IEntityContext<Entity> _context, Entities _entities, ITransa
     {
         await Task.Delay(TimeSpan.FromSeconds(delayInSeconds));
 
+        _context.Lock(this);
+
         Set(int32: Int32 + offset);
 
         return Int32 ?? 0;

--- a/test/blueprints/Do.Test.Blueprints.Service/Orm/Entity.cs
+++ b/test/blueprints/Do.Test.Blueprints.Service/Orm/Entity.cs
@@ -100,6 +100,18 @@ public class Entity(IEntityContext<Entity> _context, Entities _entities, ITransa
         string? @string = default
     ) => Set(@string: @string);
 
+    public virtual async Task<int> LockAndIncrementInt32(
+        int offset = 1,
+        int delayInSeconds = 5
+    )
+    {
+        await Task.Delay(TimeSpan.FromSeconds(delayInSeconds));
+
+        Set(int32: Int32 + offset);
+
+        return Int32 ?? 0;
+    }
+
     protected virtual void Set(
         Guid? guid = default,
         string? @string = default,

--- a/unreleased.md
+++ b/unreleased.md
@@ -1,1 +1,6 @@
 # Unreleased
+
+## Improvements
+
+- Add `Lock` to `IEntityContext` to enable select for update for making critical
+  updates in sync


### PR DESCRIPTION
Expose session lock in `IEntityContext` to enable syncing crucial updates.

## Tasks

- [x] Create case for locking
- [x] Implement and test `Lock` to `IEntityContext`

## Additional Tasks

- [x] make test tokens human readable
