### PR TITLE
Issue / Endpoint in Logs

### DIFF
--- a/docs/features/database.md
+++ b/docs/features/database.md
@@ -23,7 +23,7 @@ Adds local Sqlite database setup which creates local sqlite database in
 documents folder with given name.
 
 ```csharp
-c => c.AddSqlite(fileName: "test.db")
+c => c.Sqlite(fileName: "test.db")
 ```
 
 ## MySql

--- a/docs/features/exception-handling.md
+++ b/docs/features/exception-handling.md
@@ -8,7 +8,7 @@ app.Features.AddExceptionHandling(...);
 
 ## Default
 
-Adds default exception handler.
+Adds default exception handler as well as middleware to log exceptions.
 
 ```csharp
 c => c.Default(typeUrlFormat: "https://my-service.com/errors/{0}")

--- a/docs/features/logging.md
+++ b/docs/features/logging.md
@@ -10,18 +10,9 @@ app.Features.AddLogging(...);
 
 ## Request
 
-This implementation logs incoming request and related response information
-along with exception logging.
+This implementation creates a log scope for business method endpoints and logs
+begin and end with response status.
 
 ```csharp
-c => c.Request()
-```
-
-By default it adds a logging middeware for printing log messages to console.
-
-```csharp
-configurator.ConfigureMiddlewareCollection(middlewares =>
-{
-    middlewares.Add<RequestLogMiddleware>(order: ...);
-});
+c => c.Request(singleLine: false)
 ```

--- a/src/blueprints/Do.Blueprints.Service.Application/ExceptionHandling/Default/DefaultExceptionHandlingFeature.cs
+++ b/src/blueprints/Do.Blueprints.Service.Application/ExceptionHandling/Default/DefaultExceptionHandlingFeature.cs
@@ -1,7 +1,9 @@
 ﻿using Do.Architecture;
 using Do.Configuration;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using System.Text;
 
 namespace Do.ExceptionHandling.Default;
 
@@ -10,6 +12,19 @@ public class DefaultExceptionHandlingFeature(Setting<string>? _typeUrlFormat = d
 {
     public void Configure(LayerConfigurator configurator)
     {
+        configurator.ConfigureConfigurationBuilder(configuration =>
+        {
+            configuration.AddJsonStream(new MemoryStream(Encoding.UTF8.GetBytes("""
+            {
+              "Logging": {
+                "LogLevel": {
+                  "Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware": "None"
+                }
+              }
+            }
+            """)));
+        });
+
         configurator.ConfigureDomainTypeCollection(types =>
         {
             types.Add<HandledException>();
@@ -39,6 +54,7 @@ public class DefaultExceptionHandlingFeature(Setting<string>? _typeUrlFormat = d
         {
             middlewares.Add(app =>
                 {
+                    app.UseMiddleware<ExceptionLoggerMiddleware>();
                     app.UseExceptionHandler();
                     app.UseStatusCodePages();
                 },

--- a/src/blueprints/Do.Blueprints.Service.Application/ExceptionHandling/Default/ExceptionLoggerMiddleware.cs
+++ b/src/blueprints/Do.Blueprints.Service.Application/ExceptionHandling/Default/ExceptionLoggerMiddleware.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Do.ExceptionHandling.Default;
+
+public class ExceptionLoggerMiddleware(ILogger<ExceptionLoggerMiddleware> _logger, RequestDelegate _next)
+{
+    public async Task Invoke(HttpContext context)
+    {
+        await _next(context);
+
+        var feature = context.Features.Get<IExceptionHandlerFeature>();
+        if (feature?.Error is null) { return; }
+
+        _logger.Log(
+            context.Response.StatusCode >= 500 ? LogLevel.Error : LogLevel.Warning,
+            feature?.Error,
+            feature?.Error.Message
+        );
+    }
+}

--- a/src/blueprints/Do.Blueprints.Service.Application/Logging/Request/AddMappedMethodAttributeConvention.cs
+++ b/src/blueprints/Do.Blueprints.Service.Application/Logging/Request/AddMappedMethodAttributeConvention.cs
@@ -1,0 +1,13 @@
+﻿using Do.RestApi.Configuration;
+
+namespace Do.Logging.Request;
+
+public class AddMappedMethodAttributeConvention : IApiModelConvention<ActionModelContext>
+{
+    public void Apply(ActionModelContext context)
+    {
+        if (context.Action.MappedMethod is null) { return; }
+
+        context.Action.AdditionalAttributes.Add($"{typeof(MappedMethodAttribute).FullName}(\"{context.Controller.MappedType.FullName}\", \"{context.Action.MappedMethod.Name}\")");
+    }
+}

--- a/src/blueprints/Do.Blueprints.Service.Application/Logging/Request/MappedMethodAttribute.cs
+++ b/src/blueprints/Do.Blueprints.Service.Application/Logging/Request/MappedMethodAttribute.cs
@@ -1,0 +1,9 @@
+﻿namespace Do.Logging.Request;
+
+[AttributeUsage(AttributeTargets.Method)]
+public class MappedMethodAttribute(string typeFullName, string methodName)
+    : Attribute
+{
+    public string TypeFullName { get; } = typeFullName;
+    public string MethodName { get; } = methodName;
+}

--- a/src/blueprints/Do.Blueprints.Service.Application/Logging/Request/RequestLogMiddleware.cs
+++ b/src/blueprints/Do.Blueprints.Service.Application/Logging/Request/RequestLogMiddleware.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.AspNetCore.Diagnostics;
-using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 
 namespace Do.Logging.Request;
@@ -10,25 +9,8 @@ public class RequestLogMiddleware(ILogger<RequestLogMiddleware> _logger, Request
     {
         _logger.LogInformation(message: $"Begin: {context.Request.Path}");
 
-        try
-        {
-            await _next(context);
+        await _next(context);
 
-            var exception = context.Features.Get<IExceptionHandlerFeature>();
-            if (exception?.Error is not null)
-            {
-                _logger.LogError(exception: exception.Error, message: exception.Error.Message);
-            }
-        }
-        catch (Exception e)
-        {
-            _logger.LogError(exception: e, message: e.Message);
-
-            throw;
-        }
-        finally
-        {
-            _logger.LogInformation(message: $"End: {context.Request.Path} StatusCode: {context.Response.StatusCode}");
-        }
+        _logger.LogInformation(message: $"End: {context.Request.Path} StatusCode: {context.Response.StatusCode}");
     }
 }

--- a/src/blueprints/Do.Blueprints.Service.Application/Logging/Request/RequestLoggingExtensions.cs
+++ b/src/blueprints/Do.Blueprints.Service.Application/Logging/Request/RequestLoggingExtensions.cs
@@ -5,6 +5,7 @@ namespace Do;
 
 public static class RequestLoggingExtensions
 {
-    public static RequestLoggingFeature Request(this LoggingConfigurator _) =>
-        new();
+    public static RequestLoggingFeature Request(this LoggingConfigurator _,
+        bool singleLine = false
+    ) => new(singleLine: singleLine);
 }

--- a/src/blueprints/Do.Blueprints.Service.Application/Logging/Request/RequestLoggingFeature.cs
+++ b/src/blueprints/Do.Blueprints.Service.Application/Logging/Request/RequestLoggingFeature.cs
@@ -3,7 +3,8 @@ using Microsoft.Extensions.Logging;
 
 namespace Do.Logging.Request;
 
-public class RequestLoggingFeature : IFeature<LoggingConfigurator>
+public class RequestLoggingFeature(bool singleLine)
+    : IFeature<LoggingConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
@@ -11,8 +12,16 @@ public class RequestLoggingFeature : IFeature<LoggingConfigurator>
         {
             logging.AddSimpleConsole(options =>
             {
-                options.SingleLine = true;
+                options.IncludeScopes = true;
+                options.SingleLine = singleLine;
+                options.TimestampFormat = "yyyy.MM.dd HH:mm:ss.fff ";
+                options.UseUtcTimestamp = true;
             });
+        });
+
+        configurator.ConfigureApiModelConventions(conventions =>
+        {
+            conventions.Add(new AddMappedMethodAttributeConvention());
         });
 
         configurator.ConfigureMiddlewareCollection(middlewares =>

--- a/src/blueprints/Do.Blueprints.Service.Application/Logging/Request/RequestLoggingFeature.cs
+++ b/src/blueprints/Do.Blueprints.Service.Application/Logging/Request/RequestLoggingFeature.cs
@@ -17,7 +17,7 @@ public class RequestLoggingFeature : IFeature<LoggingConfigurator>
 
         configurator.ConfigureMiddlewareCollection(middlewares =>
         {
-            middlewares.Add<RequestLogMiddleware>(order: -9);
+            middlewares.Add<RequestLogMiddleware>(order: -20);
         });
     }
 }

--- a/unreleased.md
+++ b/unreleased.md
@@ -1,1 +1,8 @@
 # Unreleased
+
+## Improvements
+
+- `RequestLoggingFeature` now uses target domain method as category
+- `4xx` is now logged in warning level leaving only `5xx` in error level
+- Single line is now configurable from outside of `RequestLoggingFeature`
+- Log now uses timestamp and trace id in log message


### PR DESCRIPTION
Include endpoint name in all logs to make it easy to find which endpoint has
failed when info is closed.

## Tasks

- [x] 4xx should be warning
- [x] include mapped method name in logs
- [x] include date and time
- [x] singleline should be configurable
- [x] include trace id
