### PR TITLE
Issue / Rebranding

### DIFF
--- a/unreleased.md
+++ b/unreleased.md
@@ -1,1 +1,8 @@
 # Unreleased
+
+## Improvements
+
+- __DO__ is renamed as __Baked Objects__
+  - Root namespace is `Baked`
+  - `Forge` is now `Bake`
+  - `Bluprints` are now `Recipes`


### PR DESCRIPTION
Rebrand the project.

### Motivation

The name `DO` was simple and denoting the notion of Domain Objects, which is
good. But the problem is it is too common of a name and has the potential of
requiring workarounds when it comes to publishing it.

- `do.dev` is taken
- `do` is a keyword in bash, can't make a cli named `do`
- `Do.` prefix is taken or forbidden in nuget

### Constraints

- At the core of the project lies the idea of creating everything out of domain
  objects. So the name should somehow imply or have a reference to this idea.
- Nuget prefix should be available.
- Domain should be easier to find.

### Alternatives

- `Doob` from `Domain Objects`
- `Baked` from `Baked Objects` as a reference to `Naked Objects`
  - `Bake` in place for `Forge`
  - `Recipe` in place for `Blueprint`

### Tasks

- [ ] ...

### Additional Tasks

- [ ] Improve homepage to tell more about the project
  - give reference to naked objects
  - introduce each section with a card-like comp
  - give link to nuget and github (give us a star)
- [ ] update repo name in mouseless website pr lists
